### PR TITLE
Refactor : : 검색-노드 연결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,8 @@ services:
     ports:
       - "9200:9200"
       - "9600:9600"
-    
+    volumes:
+      - opensearch_data:/usr/share/opensearch/data
     networks:
       - django-network
 
@@ -65,6 +66,7 @@ services:
 
 volumes:
   db_data:
+  opensearch_data:
 
 networks:
   django-network:

--- a/search/documents.py
+++ b/search/documents.py
@@ -1,7 +1,7 @@
 from django_opensearch_dsl import Document
 from opensearch_dsl import Document
 from memo.models import Memo
-
+from node.models import Node
 #model과 document를 연결하는 곳
 #document는 Opensearch에 저장할 데이터를 정의
 
@@ -22,8 +22,20 @@ class MemoDocument(Document):
             'created_at',
             'deleted_at',
         ]
-    # 메모 검색을 위한 메소드
-    @classmethod
-    def search_memo(cls, query):
-        # content 필드에 대해 full-text search
-        return cls.search().filter('match', content=query)
+
+class NodeDocument(Document):
+    class Index:
+        name = 'node'
+
+    class Django:
+        model = Node  # Node 모델을 참조하여 매핑
+
+        # Node 모델에서 정의된 필드를 Openearch 필드로 자동 매핑
+        fields = [
+            'node_id',
+            'name',
+            'created_at',
+            'is_deleted',
+            'deleted_at',
+            'node_img',
+        ]

--- a/search/signals.py
+++ b/search/signals.py
@@ -2,6 +2,8 @@ from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from memo.models import Memo
 from .documents import MemoDocument
+from node.models import Node
+from .documents import NodeDocument
 
 # memo앱의 save이벤트가 발생하면 index_memo함수 실행
 @receiver(post_save, sender=Memo)
@@ -23,3 +25,18 @@ def index_memo(sender, instance, created, **kwargs):
 def delete_memo_from_index(sender, instance, **kwargs):
     MemoDocument.get(id=instance.memo_id).delete()
     
+
+@receiver(post_save, sender=Node)
+def index_node(sender, instance, **kwargs):
+    node_document = NodeDocument(meta={'id': instance.node_id})
+    node_document.node_id = instance.node_id
+    node_document.name = instance.name
+    node_document.created_at = instance.created_at
+    node_document.is_deleted = instance.is_deleted
+    node_document.deleted_at = instance.deleted_at
+    node_document.node_img = instance.node_img
+    node_document.save(index='node')
+
+@receiver(post_delete, sender=Node)
+def delete_node_from_index(sender, instance, **kwargs):
+    NodeDocument.get(id=instance.node_id).delete()

--- a/search/signals.py
+++ b/search/signals.py
@@ -39,4 +39,4 @@ def index_node(sender, instance, **kwargs):
 
 @receiver(post_delete, sender=Node)
 def delete_node_from_index(sender, instance, **kwargs):
-    NodeDocument.get(id=instance.node_id).delete()
+    NodeDocument(meta={'id': instance.node_id}).get(id=instance.node_id).delete()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[refactor] 검색기능 노드 연동 #45

## 📝 작업 내용

검색-노드 연결 메모 내용을 적으면 메모의 필드만 반환되고 이름을 적으면 node의 필드만 반환됨
opeansearch에도 볼륨을 추가하여 서버를 껐다 켜도 document가 유지됨

![노드조회](https://github.com/user-attachments/assets/754d167f-55f2-45f2-a427-58ea85554e03)
![메모 조회](https://github.com/user-attachments/assets/92927eb9-a513-4566-bf3d-57d6ee19a822)

