### PR TITLE
fix : : celery-beat 비활성화

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -281,10 +281,11 @@ CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND')
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
-
+'''
 CELERY_BEAT_SCHEDULE = {
     'example-task': {
         'task': 'myapp.tasks.example_task',
         'schedule': crontab(minute='*/1'),  # 매 1분마다 실행
     },
 }
+'''


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[fix] celery beat 비활성화 #83

## 📝 작업 내용

원래 새로고침 등 주기적으로 일어나야하는 비동기 task를 실행하려고 넣어뒀던
celery beat를 안써서 오류메시지 지우고, docker를 더 가볍게 사용하기 위해 제거


### 스크린샷 (선택)

이슈 참고